### PR TITLE
feat: add missing forward declare for AccelerationStructure Vulkan

### DIFF
--- a/Include/Extensions/NRIWrapperVK.h
+++ b/Include/Extensions/NRIWrapperVK.h
@@ -8,6 +8,8 @@ NRI_FORWARD_STRUCT(VkImageSubresourceRange);
 
 NRI_NAMESPACE_BEGIN
 
+NRI_FORWARD_STRUCT(AccelerationStructure);
+
 typedef uint64_t NRIVkCommandPool;
 typedef uint64_t NRIVkImage;
 typedef uint64_t NRIVkBuffer;


### PR DESCRIPTION
I needed to add this forward declare to compile the raytracing examples under NRISamples.

https://github.com/NVIDIAGameWorks/NRISamples/pull/3