### PR TITLE
feat: improve output from ReportMessage

### DIFF
--- a/Source/D3D11/DeviceD3D11.cpp
+++ b/Source/D3D11/DeviceD3D11.cpp
@@ -65,7 +65,11 @@ Result CreateDeviceD3D11(const DeviceCreationD3D11Desc& deviceCreationD3D11Desc,
 DeviceD3D11::DeviceD3D11(const CallbackInterface& callbacks, StdAllocator<uint8_t>& stdAllocator) :
     DeviceBase(callbacks, stdAllocator)
     , m_CommandQueues(GetStdAllocator())
-{}
+{
+    m_Desc.graphicsAPI = GraphicsAPI::D3D11;
+    m_Desc.nriVersionMajor = NRI_VERSION_MAJOR;
+    m_Desc.nriVersionMinor = NRI_VERSION_MINOR;
+}
 
 DeviceD3D11::~DeviceD3D11()
 {
@@ -297,10 +301,6 @@ void DeviceD3D11::FillDesc(bool isValidationEnabled)
             timestampFrequency = data.Frequency;
         }
     }
-
-    m_Desc.graphicsAPI = GraphicsAPI::D3D11;
-    m_Desc.nriVersionMajor = NRI_VERSION_MAJOR;
-    m_Desc.nriVersionMinor = NRI_VERSION_MINOR;
 
     m_Desc.viewportMaxNum = D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE;
     m_Desc.viewportSubPixelBits = D3D11_SUBPIXEL_FRACTIONAL_BIT_COUNT;

--- a/Source/D3D12/DeviceD3D12.cpp
+++ b/Source/D3D12/DeviceD3D12.cpp
@@ -63,6 +63,9 @@ DeviceD3D12::DeviceD3D12(const CallbackInterface& callbacks, StdAllocator<uint8_
     , m_DrawIndexedCommandSignatures(GetStdAllocator())
 {
     m_FreeDescriptors.resize(DESCRIPTOR_HEAP_TYPE_NUM, Vector<DescriptorHandle>(GetStdAllocator()));
+    m_Desc.graphicsAPI = GraphicsAPI::D3D12;
+    m_Desc.nriVersionMajor = NRI_VERSION_MAJOR;
+    m_Desc.nriVersionMinor = NRI_VERSION_MINOR;
 }
 
 DeviceD3D12::~DeviceD3D12()
@@ -473,9 +476,6 @@ void DeviceD3D12::FillDesc(bool enableValidation)
         m_Desc.adapterDesc.vendor = GetVendorFromID(desc.VendorId);
     }
 
-    m_Desc.graphicsAPI = GraphicsAPI::D3D12;
-    m_Desc.nriVersionMajor = NRI_VERSION_MAJOR;
-    m_Desc.nriVersionMinor = NRI_VERSION_MINOR;
 
     m_Desc.viewportMaxNum = D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE;
     m_Desc.viewportSubPixelBits = D3D12_SUBPIXEL_FRACTIONAL_BIT_COUNT;

--- a/Source/Shared/SharedExternal.cpp
+++ b/Source/Shared/SharedExternal.cpp
@@ -941,7 +941,12 @@ void nri::DeviceBase::ReportMessage(nri::Message messageType, const char* file, 
     file = temp ? temp + 1 : file;
 
     char message[4096];
-    int written = snprintf(message, GetCountOf(message), "NRI::%s(%s:%u) - %s::%s - ", messageTypeName, file, line, graphicsAPIName, desc.adapterDesc.description);
+    int written = 0;
+    if(desc.adapterDesc.description[0] == '\0') {
+       written = snprintf(message, GetCountOf(message), "NRI::%s(%s:%u) - %s::Unknown - ", messageTypeName, file, line, graphicsAPIName);
+    } else {
+       written = snprintf(message, GetCountOf(message), "NRI::%s(%s:%u) - %s::%s - ", messageTypeName, file, line, graphicsAPIName, desc.adapterDesc.description);
+    }
 
     va_list	argptr;
     va_start(argptr, format);

--- a/Source/VK/DeviceVK.cpp
+++ b/Source/VK/DeviceVK.cpp
@@ -137,6 +137,9 @@ DeviceVK::DeviceVK(const CallbackInterface& callbacks, const StdAllocator<uint8_
     m_PhysicalDeviceIndices(GetStdAllocator()),
     m_ConcurrentSharingModeQueueIndices(GetStdAllocator())
 {
+    m_Desc.graphicsAPI = GraphicsAPI::VULKAN;
+    m_Desc.nriVersionMajor = NRI_VERSION_MAJOR;
+    m_Desc.nriVersionMinor = NRI_VERSION_MINOR;
 }
 
 DeviceVK::~DeviceVK()
@@ -862,10 +865,6 @@ void DeviceVK::FillDesc(bool enableValidation)
 #endif
 
     const VkPhysicalDeviceLimits& limits = props.properties.limits;
-
-    m_Desc.graphicsAPI = GraphicsAPI::VULKAN;
-    m_Desc.nriVersionMajor = NRI_VERSION_MAJOR;
-    m_Desc.nriVersionMinor = NRI_VERSION_MINOR;
 
     m_Desc.viewportMaxNum = limits.maxViewports;
     m_Desc.viewportSubPixelBits = limits.viewportSubPixelBits;


### PR DESCRIPTION
so when you create a vulkan device using NRIVkWrapper you can run into a situation where the output from logging will show D3D11 since this is the 0 index and the desc will get filled in later so the output will be formatted as follows:

```
D3D11:: - <message>-
```

just a minor tweak to the output text. mDesc.graphicsAPI is know when the object is instantiated makes sense to set these properties during constructor.