### PR TITLE
Fix command signature leak

### DIFF
--- a/Source/D3D12/DeviceD3D12.cpp
+++ b/Source/D3D12/DeviceD3D12.cpp
@@ -316,7 +316,7 @@ void DeviceD3D12::GetMemoryInfo(MemoryLocation memoryLocation, const D3D12_RESOU
     memoryDesc.mustBeDedicated = RequiresDedicatedAllocation(memoryDesc.type);
 }
 
-ID3D12CommandSignature* DeviceD3D12::CreateCommandSignature(D3D12_INDIRECT_ARGUMENT_TYPE indirectArgumentType, uint32_t stride) {
+ComPtr<ID3D12CommandSignature> DeviceD3D12::CreateCommandSignature(D3D12_INDIRECT_ARGUMENT_TYPE indirectArgumentType, uint32_t stride) {
     D3D12_INDIRECT_ARGUMENT_DESC indirectArgumentDesc = {};
     indirectArgumentDesc.Type = indirectArgumentType;
 
@@ -326,7 +326,7 @@ ID3D12CommandSignature* DeviceD3D12::CreateCommandSignature(D3D12_INDIRECT_ARGUM
     commandSignatureDesc.NodeMask = NRI_NODE_MASK;
     commandSignatureDesc.ByteStride = stride;
 
-    ID3D12CommandSignature* commandSignature = nullptr;
+    ComPtr<ID3D12CommandSignature> commandSignature = nullptr;
     HRESULT hr = m_Device->CreateCommandSignature(&commandSignatureDesc, nullptr, IID_PPV_ARGS(&commandSignature));
     if (FAILED(hr))
         REPORT_ERROR(this, "ID3D12Device::CreateCommandSignature() failed, result = 0x%08X!", hr);
@@ -339,7 +339,7 @@ ID3D12CommandSignature* DeviceD3D12::GetDrawCommandSignature(uint32_t stride) {
     if (commandSignatureIt != m_DrawCommandSignatures.end())
         return commandSignatureIt->second;
 
-    ID3D12CommandSignature* commandSignature = CreateCommandSignature(D3D12_INDIRECT_ARGUMENT_TYPE_DRAW, stride);
+    ComPtr<ID3D12CommandSignature> commandSignature = CreateCommandSignature(D3D12_INDIRECT_ARGUMENT_TYPE_DRAW, stride);
     m_DrawCommandSignatures[stride] = commandSignature;
 
     return commandSignature;
@@ -350,7 +350,7 @@ ID3D12CommandSignature* DeviceD3D12::GetDrawIndexedCommandSignature(uint32_t str
     if (commandSignatureIt != m_DrawIndexedCommandSignatures.end())
         return commandSignatureIt->second;
 
-    ID3D12CommandSignature* commandSignature = CreateCommandSignature(D3D12_INDIRECT_ARGUMENT_TYPE_DRAW_INDEXED, stride);
+    ComPtr<ID3D12CommandSignature> commandSignature = CreateCommandSignature(D3D12_INDIRECT_ARGUMENT_TYPE_DRAW_INDEXED, stride);
     m_DrawIndexedCommandSignatures[stride] = commandSignature;
 
     return commandSignature;
@@ -361,7 +361,7 @@ ID3D12CommandSignature* DeviceD3D12::GetDrawMeshCommandSignature(uint32_t stride
     if (commandSignatureIt != m_DrawMeshCommandSignatures.end())
         return commandSignatureIt->second;
 
-    ID3D12CommandSignature* commandSignature = CreateCommandSignature(D3D12_INDIRECT_ARGUMENT_TYPE_DISPATCH_MESH, stride);
+    ComPtr<ID3D12CommandSignature> commandSignature = CreateCommandSignature(D3D12_INDIRECT_ARGUMENT_TYPE_DISPATCH_MESH, stride);
     m_DrawMeshCommandSignatures[stride] = commandSignature;
 
     return commandSignature;

--- a/Source/D3D12/DeviceD3D12.h
+++ b/Source/D3D12/DeviceD3D12.h
@@ -148,7 +148,7 @@ struct DeviceD3D12 final : public DeviceBase {
   private:
     void FillDesc();
     MemoryType GetMemoryType(MemoryLocation memoryLocation, const D3D12_RESOURCE_DESC& resourceDesc) const;
-    ID3D12CommandSignature* CreateCommandSignature(D3D12_INDIRECT_ARGUMENT_TYPE indirectArgumentType, uint32_t stride);
+    ComPtr<ID3D12CommandSignature> CreateCommandSignature(D3D12_INDIRECT_ARGUMENT_TYPE indirectArgumentType, uint32_t stride);
 
   private:
     ComPtr<ID3D12DeviceBest> m_Device;


### PR DESCRIPTION
I was getting a warning for command signature when dumping alive objects, but after changing from `ICommandSignature*` to `ComPtr<ICommandSignature>`, it stopped.