### PR TITLE
Fixed D3D12 crash with bindless samplers

### DIFF
--- a/Source/D3D12/PipelineLayoutD3D12.cpp
+++ b/Source/D3D12/PipelineLayoutD3D12.cpp
@@ -95,10 +95,13 @@ Result PipelineLayoutD3D12::Create(const PipelineLayoutDesc& pipelineLayoutDesc)
             rootParameter.DescriptorTable.pDescriptorRanges = &descriptorRanges[totalRangeNum];
 
             D3D12_DESCRIPTOR_RANGE_FLAGS descriptorRangeFlags = D3D12_DESCRIPTOR_RANGE_FLAG_NONE;
-            if (descriptorSetDesc.partiallyBound && rangeType != D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER) 
+            if (descriptorSetDesc.partiallyBound) 
             {
                 descriptorRangeFlags |= D3D12_DESCRIPTOR_RANGE_FLAG_DESCRIPTORS_VOLATILE;
-                descriptorRangeFlags |= D3D12_DESCRIPTOR_RANGE_FLAG_DATA_VOLATILE;
+                if (rangeType != D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER)
+                {
+                    descriptorRangeFlags |= D3D12_DESCRIPTOR_RANGE_FLAG_DATA_VOLATILE;
+                }
             }
 
             D3D12_DESCRIPTOR_RANGE1& descriptorRange = descriptorRanges[totalRangeNum + groupedRangeNum];

--- a/Source/D3D12/PipelineLayoutD3D12.cpp
+++ b/Source/D3D12/PipelineLayoutD3D12.cpp
@@ -70,9 +70,6 @@ Result PipelineLayoutD3D12::Create(const PipelineLayoutDesc& pipelineLayoutDesc)
         D3D12_ROOT_PARAMETER1 rootParameter = {};
         rootParameter.ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
 
-        D3D12_DESCRIPTOR_RANGE_FLAGS descriptorRangeFlags =
-            descriptorSetDesc.partiallyBound ? D3D12_DESCRIPTOR_RANGE_FLAG_DESCRIPTORS_VOLATILE | D3D12_DESCRIPTOR_RANGE_FLAG_DATA_VOLATILE : D3D12_DESCRIPTOR_RANGE_FLAG_NONE;
-
         uint32_t groupedRangeNum = 0;
         D3D12_DESCRIPTOR_RANGE_TYPE groupedRangeType = {};
         for (uint32_t j = 0; j < descriptorSetDesc.rangeNum; j++) {
@@ -96,6 +93,13 @@ Result PipelineLayoutD3D12::Create(const PipelineLayoutDesc& pipelineLayoutDesc)
 
             rootParameter.ShaderVisibility = shaderVisibility;
             rootParameter.DescriptorTable.pDescriptorRanges = &descriptorRanges[totalRangeNum];
+
+            D3D12_DESCRIPTOR_RANGE_FLAGS descriptorRangeFlags = D3D12_DESCRIPTOR_RANGE_FLAG_NONE;
+            if (descriptorSetDesc.partiallyBound && rangeType != D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER) 
+            {
+                descriptorRangeFlags |= D3D12_DESCRIPTOR_RANGE_FLAG_DESCRIPTORS_VOLATILE;
+                descriptorRangeFlags |= D3D12_DESCRIPTOR_RANGE_FLAG_DATA_VOLATILE;
+            }
 
             D3D12_DESCRIPTOR_RANGE1& descriptorRange = descriptorRanges[totalRangeNum + groupedRangeNum];
             descriptorRange.RangeType = rangeType;


### PR DESCRIPTION
https://learn.microsoft.com/en-us/windows/win32/direct3d12/root-signature-version-1-1
> At most one of the DATA flags can be specified at a time, **except for Sampler descriptor ranges which do not support DATA flags at all since samplers do not point to data**.
