### PR TITLE
bugfix: tweak surface caps for maxImageExtents when its 0

### DIFF
--- a/Source/VK/SwapChainVK.cpp
+++ b/Source/VK/SwapChainVK.cpp
@@ -151,8 +151,8 @@ Result SwapChainVK::Create(const SwapChainDesc& swapChainDesc) {
         RETURN_ON_FAILURE(&m_Device, isHeightValid, Result::INVALID_ARGUMENT, "swapChainDesc.height is out of [%u, %u] range", sc.surfaceCapabilities.minImageExtent.height,
             sc.surfaceCapabilities.maxImageExtent.height);
 
-        bool isTextureNumValid = textureNum >= sc.surfaceCapabilities.minImageCount && textureNum <= sc.surfaceCapabilities.maxImageCount;
-        RETURN_ON_FAILURE(&m_Device, isTextureNumValid, Result::INVALID_ARGUMENT, "swapChainDesc.height is out of [%u, %u] range", sc.surfaceCapabilities.minImageCount,
+        bool isTextureNumValid = textureNum >= sc.surfaceCapabilities.minImageCount && (textureNum <= sc.surfaceCapabilities.maxImageCount || sc.surfaceCapabilities.maxImageCount == 0);
+        RETURN_ON_FAILURE(&m_Device, isTextureNumValid, Result::INVALID_ARGUMENT, "swapChainDesc.textureNum is out of [%u, %u] range", sc.surfaceCapabilities.minImageCount,
             sc.surfaceCapabilities.maxImageCount);
     }
 


### PR DESCRIPTION
this is listed in the vulkan spec: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSurfaceCapabilitiesKHR.html

```
maxImageCount is the maximum number of images the specified device supports for a swapchain created for the surface, and will be either 0, or greater than or equal to minImageCount. A value of 0 means that there is no limit on the number of images, though there may be limits related to the total amount of memory used by presentable images.
```