### PR TITLE
bugfix: fix vulkan validation error VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT /VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT

### DIFF
--- a/Source/VK/TextureVK.cpp
+++ b/Source/VK/TextureVK.cpp
@@ -23,9 +23,14 @@ Result TextureVK::Create(const TextureDesc& textureDesc) {
     const VkSharingMode sharingMode = m_Device.IsConcurrentSharingModeEnabledForImages() ? VK_SHARING_MODE_CONCURRENT : VK_SHARING_MODE_EXCLUSIVE;
     const Vector<uint32_t>& queueIndices = m_Device.GetConcurrentSharingModeQueueIndices();
 
-    VkImageCreateFlags flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT; // typeless
-    if (textureDesc.arraySize > 1)
-        flags |= (textureDesc.type == nri::TextureType::TEXTURE_3D) ? VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT : VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
+   VkImageCreateFlags flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT; // typeless
+    const FormatProps& formatProps = GetFormatProps(textureDesc.format);
+    if (formatProps.blockWidth > 1)
+        flags |= VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT; // format can be used to create a view with an uncompressed format (1 texel covers 1 block)
+    if (textureDesc.arraySize >= 6 && textureDesc.width == textureDesc.height)
+        flags |= VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT; // allow cube maps
+    if (textureDesc.type == nri::TextureType::TEXTURE_3D)
+        flags |= VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT; // allow 3D demotion to a set of layers // TODO: hook up "VK_EXT_image_2d_view_of_3d"?
     if (m_Device.GetDesc().isProgrammableSampleLocationsSupported && textureDesc.format >= Format::D16_UNORM)
         flags |= VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT;
 

--- a/Source/VK/TextureVK.cpp
+++ b/Source/VK/TextureVK.cpp
@@ -25,7 +25,7 @@ Result TextureVK::Create(const TextureDesc& textureDesc) {
 
     VkImageCreateFlags flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT; // typeless
     if (textureDesc.arraySize > 1)
-        flags |= VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT | VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
+        flags |= (textureDesc.type == nri::TextureType::TEXTURE_3D) ? VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT : VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
     if (m_Device.GetDesc().isProgrammableSampleLocationsSupported && textureDesc.format >= Format::D16_UNORM)
         flags |= VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT;
 


### PR DESCRIPTION
https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkImageCreateInfo.html

If flags contains VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT, imageType must be VK_IMAGE_TYPE_2D
If flags contains VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT, extent.width and extent.height must be equal

If flags contains VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT, imageType must be VK_IMAGE_TYPE_3D

these rules overlap and are incompatible. if its a 2d with array then its a cubemap but can't also be a 3D image at the same time. 