### PR TITLE
Fixed resource allocation and memory binding for device wrapper

### DIFF
--- a/Include/Extensions/NRIWrapperD3D12.h
+++ b/Include/Extensions/NRIWrapperD3D12.h
@@ -5,6 +5,7 @@
 #include "NRIDeviceCreation.h"
 
 NRI_FORWARD_STRUCT(ID3D12Heap);
+NRI_FORWARD_STRUCT(D3D12_HEAP_DESC);
 NRI_FORWARD_STRUCT(ID3D12Device);
 NRI_FORWARD_STRUCT(ID3D12Resource);
 NRI_FORWARD_STRUCT(ID3D12CommandQueue);
@@ -49,6 +50,7 @@ NRI_STRUCT(TextureD3D12Desc)
 NRI_STRUCT(MemoryD3D12Desc)
 {
     ID3D12Heap* d3d12Heap;
+    const D3D12_HEAP_DESC* d3d12HeapDesc;
 };
 
 NRI_STRUCT(AccelerationStructureD3D12Desc)

--- a/Source/D3D11/BufferD3D11.cpp
+++ b/Source/D3D11/BufferD3D11.cpp
@@ -14,6 +14,10 @@ BufferD3D11::~BufferD3D11() {
 }
 
 Result BufferD3D11::Create(const MemoryD3D11& memory) {
+    // Buffer was already created externally
+    if (m_Buffer)
+        return Result::SUCCESS;
+
     MemoryLocation memoryLocation = memory.GetType();
 
     D3D11_BUFFER_DESC desc = {};

--- a/Source/D3D11/TextureD3D11.cpp
+++ b/Source/D3D11/TextureD3D11.cpp
@@ -8,6 +8,10 @@
 using namespace nri;
 
 Result TextureD3D11::Create(const MemoryD3D11* memory) {
+    // Texture was already created externally
+    if (m_Texture)
+        return Result::SUCCESS;
+
     const DxgiFormat& dxgiFormat = GetDxgiFormat(m_Desc.format);
 
     uint32_t bindFlags = 0;

--- a/Source/D3D12/BufferD3D12.cpp
+++ b/Source/D3D12/BufferD3D12.cpp
@@ -38,6 +38,10 @@ Result BufferD3D12::BindMemory(const MemoryD3D12* memory, uint64_t offset, bool 
     MaybeUnused(isAccelerationStructureBuffer);
     const D3D12_HEAP_DESC& heapDesc = memory->GetHeapDesc();
 
+    // Buffer was already created externally
+    if (m_Buffer)
+        return Result::SUCCESS;
+
 #ifdef NRI_USE_AGILITY_SDK
     if (m_Device.GetVersion() >= 10) {
         D3D12_RESOURCE_DESC1 desc1 = {};
@@ -47,7 +51,8 @@ Result BufferD3D12::BindMemory(const MemoryD3D12* memory, uint64_t offset, bool 
         DXGI_FORMAT* castableFormats = nullptr; // TODO: add castable formats, see options12.RelaxedFormatCastingSupported
 
         if (memory->RequiresDedicatedAllocation()) {
-            HRESULT hr = m_Device->CreateCommittedResource3(&heapDesc.Properties, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED, &desc1, D3D12_BARRIER_LAYOUT_UNDEFINED, nullptr, nullptr,
+            HRESULT hr = m_Device->CreateCommittedResource3(
+                &heapDesc.Properties, heapDesc.Flags, &desc1, D3D12_BARRIER_LAYOUT_UNDEFINED, nullptr, nullptr,
                 castableFormatNum, castableFormats, IID_PPV_ARGS(&m_Buffer));
             RETURN_ON_BAD_HRESULT(&m_Device, hr, "ID3D12Device10::CreateCommittedResource3()");
         } else {
@@ -70,7 +75,7 @@ Result BufferD3D12::BindMemory(const MemoryD3D12* memory, uint64_t offset, bool 
             initialState |= D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE;
 
         if (memory->RequiresDedicatedAllocation()) {
-            HRESULT hr = m_Device->CreateCommittedResource(&heapDesc.Properties, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED, &desc, initialState, nullptr, IID_PPV_ARGS(&m_Buffer));
+            HRESULT hr = m_Device->CreateCommittedResource(&heapDesc.Properties, heapDesc.Flags, &desc, initialState, nullptr, IID_PPV_ARGS(&m_Buffer));
             RETURN_ON_BAD_HRESULT(&m_Device, hr, "ID3D12Device::CreateCommittedResource()");
         } else {
             HRESULT hr = m_Device->CreatePlacedResource(*memory, offset, &desc, initialState, nullptr, IID_PPV_ARGS(&m_Buffer));

--- a/Source/D3D12/MemoryD3D12.cpp
+++ b/Source/D3D12/MemoryD3D12.cpp
@@ -29,7 +29,7 @@ Result MemoryD3D12::Create(const MemoryType memoryType, uint64_t size) {
 
 Result MemoryD3D12::Create(const MemoryD3D12Desc& memoryDesc) {
     m_Heap = memoryDesc.d3d12Heap;
-    m_HeapDesc = m_Heap->GetDesc();
+    m_HeapDesc = m_Heap ? m_Heap->GetDesc() : *memoryDesc.d3d12HeapDesc;
 
     return Result::SUCCESS;
 }

--- a/Source/D3D12/SharedD3D12.cpp
+++ b/Source/D3D12/SharedD3D12.cpp
@@ -359,7 +359,7 @@ void nri::ConvertRects(D3D12_RECT* rectsD3D12, const Rect* rects, uint32_t rectN
 }
 
 uint64_t nri::GetMemorySizeD3D12(const MemoryD3D12Desc& memoryD3D12Desc) {
-    return memoryD3D12Desc.d3d12Heap->GetDesc().SizeInBytes;
+    return memoryD3D12Desc.d3d12Heap ? memoryD3D12Desc.d3d12Heap->GetDesc().SizeInBytes : memoryD3D12Desc.d3d12HeapDesc->SizeInBytes;
 }
 
 bool nri::GetTextureDesc(const TextureD3D12Desc& textureD3D12Desc, TextureDesc& textureDesc) {

--- a/Source/D3D12/TextureD3D12.cpp
+++ b/Source/D3D12/TextureD3D12.cpp
@@ -38,6 +38,10 @@ Result TextureD3D12::Create(const TextureD3D12Desc& textureDesc) {
 }
 
 Result TextureD3D12::BindMemory(const MemoryD3D12* memory, uint64_t offset) {
+    // Texture was already created externally
+    if (m_Texture)
+        return Result::SUCCESS;
+
     const D3D12_HEAP_DESC& heapDesc = memory->GetHeapDesc();
     D3D12_CLEAR_VALUE clearValue = {GetDxgiFormat(m_Desc.format).typed};
 
@@ -52,7 +56,7 @@ Result TextureD3D12::BindMemory(const MemoryD3D12* memory, uint64_t offset) {
         DXGI_FORMAT* castableFormats = nullptr; // TODO: add castable formats, see options12.RelaxedFormatCastingSupported
 
         if (memory->RequiresDedicatedAllocation()) {
-            HRESULT hr = m_Device->CreateCommittedResource3(&heapDesc.Properties, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED, &desc1, initialLayout,
+            HRESULT hr = m_Device->CreateCommittedResource3(&heapDesc.Properties, heapDesc.Flags, &desc1, initialLayout,
                 isRenderableSurface ? &clearValue : nullptr, nullptr, castableFormatNum, castableFormats, IID_PPV_ARGS(&m_Texture));
             RETURN_ON_BAD_HRESULT(&m_Device, hr, "ID3D12Device10::CreateCommittedResource3()");
         } else {
@@ -70,7 +74,7 @@ Result TextureD3D12::BindMemory(const MemoryD3D12* memory, uint64_t offset) {
 
         if (memory->RequiresDedicatedAllocation()) {
             HRESULT hr = m_Device->CreateCommittedResource(
-                &heapDesc.Properties, D3D12_HEAP_FLAG_CREATE_NOT_ZEROED, &desc, D3D12_RESOURCE_STATE_COMMON, isRenderableSurface ? &clearValue : nullptr, IID_PPV_ARGS(&m_Texture));
+                &heapDesc.Properties, heapDesc.Flags, &desc, D3D12_RESOURCE_STATE_COMMON, isRenderableSurface ? &clearValue : nullptr, IID_PPV_ARGS(&m_Texture));
             RETURN_ON_BAD_HRESULT(&m_Device, hr, "ID3D12Device::CreateCommittedResource()");
         } else {
             HRESULT hr = m_Device->CreatePlacedResource(*memory, offset, &desc, D3D12_RESOURCE_STATE_COMMON, isRenderableSurface ? &clearValue : nullptr, IID_PPV_ARGS(&m_Texture));

--- a/Source/VK/AccelerationStructureVK.h
+++ b/Source/VK/AccelerationStructureVK.h
@@ -23,6 +23,10 @@ struct AccelerationStructureVK {
         return m_Buffer;
     }
 
+    inline bool OwnsNativeObjects() const {
+        return m_OwnsNativeObjects;
+    }
+
     ~AccelerationStructureVK();
 
     Result Create(const AccelerationStructureDesc& accelerationStructureDesc);

--- a/Source/VK/BufferVK.h
+++ b/Source/VK/BufferVK.h
@@ -27,6 +27,10 @@ struct BufferVK {
         return m_Desc;
     }
 
+    inline bool OwnsNativeObjects() const {
+		return m_OwnsNativeObjects;
+	}
+
     ~BufferVK();
 
     Result Create(const BufferDesc& bufferDesc);

--- a/Source/VK/MemoryVK.h
+++ b/Source/VK/MemoryVK.h
@@ -30,6 +30,10 @@ struct MemoryVK {
         return m_MappedMemory;
     }
 
+    inline bool OwnsNativeObjects() const {
+        return m_OwnsNativeObjects;
+    }
+
     ~MemoryVK();
 
     Result Create(const MemoryType memoryType, uint64_t size);

--- a/Source/VK/TextureVK.h
+++ b/Source/VK/TextureVK.h
@@ -34,6 +34,10 @@ struct TextureVK {
         return GetDimension(GraphicsAPI::VULKAN, m_Desc, dimensionIndex, mip);
     }
 
+    inline bool OwnsNativeObjects() const {
+        return m_OwnsNativeObjects;
+    }
+
     ~TextureVK();
 
     Result Create(const TextureDesc& textureDesc);

--- a/Source/Validation/DeviceVal.cpp
+++ b/Source/Validation/DeviceVal.cpp
@@ -635,6 +635,10 @@ Result DeviceVal::BindBufferMemory(const BufferMemoryBindingDesc* memoryBindingD
 
         RETURN_ON_FAILURE(this, !buffer.IsBoundToMemory(), Result::INVALID_ARGUMENT, "BindBufferMemory: 'memoryBindingDescs[%u].buffer' is already bound to memory", i);
 
+        destDesc = srcDesc;
+        destDesc.memory = memory.GetImpl();
+        destDesc.buffer = buffer.GetImpl();
+
         // Skip validation if memory has been created from GAPI object using a wrapper extension
         if (memory.GetMemoryLocation() == MemoryLocation::MAX_NUM)
             continue;
@@ -652,10 +656,6 @@ Result DeviceVal::BindBufferMemory(const BufferMemoryBindingDesc* memoryBindingD
         const bool memorySizeIsUnknown = memory.GetSize() == 0;
 
         RETURN_ON_FAILURE(this, memorySizeIsUnknown || rangeMax <= memory.GetSize(), Result::INVALID_ARGUMENT, "BindBufferMemory: 'memoryBindingDescs[%u].offset' is invalid", i);
-
-        destDesc = srcDesc;
-        destDesc.memory = memory.GetImpl();
-        destDesc.buffer = buffer.GetImpl();
     }
 
     const Result result = m_CoreAPI.BindBufferMemory(m_Device, memoryBindingDescsImpl, memoryBindingDescNum);
@@ -687,6 +687,10 @@ Result DeviceVal::BindTextureMemory(const TextureMemoryBindingDesc* memoryBindin
 
         RETURN_ON_FAILURE(this, !texture.IsBoundToMemory(), Result::INVALID_ARGUMENT, "BindTextureMemory: 'memoryBindingDescs[%u].texture' is already bound to memory", i);
 
+        destDesc = srcDesc;
+        destDesc.memory = memory.GetImpl();
+        destDesc.texture = texture.GetImpl();
+
         // Skip validation if memory has been created from GAPI object using a wrapper extension
         if (memory.GetMemoryLocation() == MemoryLocation::MAX_NUM)
             continue;
@@ -704,10 +708,6 @@ Result DeviceVal::BindTextureMemory(const TextureMemoryBindingDesc* memoryBindin
         const bool memorySizeIsUnknown = memory.GetSize() == 0;
 
         RETURN_ON_FAILURE(this, memorySizeIsUnknown || rangeMax <= memory.GetSize(), Result::INVALID_ARGUMENT, "BindTextureMemory: 'memoryBindingDescs[%u].offset' is invalid", i);
-
-        destDesc = srcDesc;
-        destDesc.memory = memory.GetImpl();
-        destDesc.texture = texture.GetImpl();
     }
 
     const Result result = m_CoreAPI.BindTextureMemory(m_Device, memoryBindingDescsImpl, memoryBindingDescNum);
@@ -1028,7 +1028,8 @@ Result DeviceVal::CreateTextureD3D12(const TextureD3D12Desc& textureDesc, Textur
 }
 
 Result DeviceVal::CreateMemoryD3D12(const MemoryD3D12Desc& memoryDesc, Memory*& memory) {
-    RETURN_ON_FAILURE(this, memoryDesc.d3d12Heap != nullptr, Result::INVALID_ARGUMENT, "CreateMemoryD3D12: 'memoryDesc.d3d12Heap' is NULL");
+    RETURN_ON_FAILURE(
+        this, (memoryDesc.d3d12Heap != nullptr || memoryDesc.d3d12HeapDesc != nullptr), Result::INVALID_ARGUMENT, "CreateMemoryD3D12: 'memoryDesc.d3d12Heap' is NULL");
 
     Memory* memoryImpl = nullptr;
     const Result result = m_WrapperD3D12API.CreateMemoryD3D12(m_Device, memoryDesc, memoryImpl);


### PR DESCRIPTION
- D3D12, D3D11: Updated to not create buffer when binding to an external buffer.
- D3D12: Updated to Use heap's flags when creating resource.
- VK: Updated to not rebind external buffer and texture to memory, aswell as not recreating external memory.