### PR TITLE
feat: mark methods as overriden for Device D3D11/12/Val/Vulkan

### DIFF
--- a/Source/D3D11/DeviceD3D11.h
+++ b/Source/D3D11/DeviceD3D11.h
@@ -85,18 +85,18 @@ struct DeviceD3D11 final : public DeviceBase {
     // DeviceBase
     //================================================================================================================
 
-    inline const DeviceDesc& GetDesc() const {
+    inline const DeviceDesc& GetDesc() const  override{
         return m_Desc;
     }
 
-    void Destruct();
-    Result FillFunctionTable(CoreInterface& table) const;
-    Result FillFunctionTable(HelperInterface& table) const;
-    Result FillFunctionTable(LowLatencyInterface& table) const;
-    Result FillFunctionTable(StreamerInterface& table) const;
-    Result FillFunctionTable(SwapChainInterface& table) const;
-    Result FillFunctionTable(ResourceAllocatorInterface& table) const;
-    Result FillFunctionTable(WrapperD3D11Interface& table) const;
+    void Destruct() override;
+    Result FillFunctionTable(CoreInterface& table) const override;
+    Result FillFunctionTable(HelperInterface& table) const override;
+    Result FillFunctionTable(LowLatencyInterface& table) const override;
+    Result FillFunctionTable(StreamerInterface& table) const override;
+    Result FillFunctionTable(SwapChainInterface& table) const override;
+    Result FillFunctionTable(ResourceAllocatorInterface& table) const override;
+    Result FillFunctionTable(WrapperD3D11Interface& table) const override;
 
     //================================================================================================================
     // NRI

--- a/Source/D3D12/DeviceD3D12.h
+++ b/Source/D3D12/DeviceD3D12.h
@@ -93,20 +93,20 @@ struct DeviceD3D12 final : public DeviceBase {
     // DeviceBase
     //================================================================================================================
 
-    inline const DeviceDesc& GetDesc() const {
+    inline const DeviceDesc& GetDesc() const override{
         return m_Desc;
     }
 
-    void Destruct();
-    Result FillFunctionTable(CoreInterface& table) const;
-    Result FillFunctionTable(HelperInterface& table) const;
-    Result FillFunctionTable(LowLatencyInterface& table) const;
-    Result FillFunctionTable(MeshShaderInterface& table) const;
-    Result FillFunctionTable(RayTracingInterface& table) const;
-    Result FillFunctionTable(StreamerInterface& table) const;
-    Result FillFunctionTable(SwapChainInterface& table) const;
-    Result FillFunctionTable(ResourceAllocatorInterface& table) const;
-    Result FillFunctionTable(WrapperD3D12Interface& table) const;
+    void Destruct() override;
+    Result FillFunctionTable(CoreInterface& table) const override;
+    Result FillFunctionTable(HelperInterface& table) const override;
+    Result FillFunctionTable(LowLatencyInterface& table) const override;
+    Result FillFunctionTable(MeshShaderInterface& table) const override;
+    Result FillFunctionTable(RayTracingInterface& table) const override;
+    Result FillFunctionTable(StreamerInterface& table) const override;
+    Result FillFunctionTable(SwapChainInterface& table) const override;
+    Result FillFunctionTable(ResourceAllocatorInterface& table) const override;
+    Result FillFunctionTable(WrapperD3D12Interface& table) const override;
 
     //================================================================================================================
     // NRI

--- a/Source/VK/DeviceVK.h
+++ b/Source/VK/DeviceVK.h
@@ -91,20 +91,20 @@ struct DeviceVK final : public DeviceBase {
     // DeviceBase
     //================================================================================================================
 
-    inline const DeviceDesc& GetDesc() const {
+    inline const DeviceDesc& GetDesc() const override{
         return m_Desc;
     }
 
-    void Destruct();
-    Result FillFunctionTable(CoreInterface& table) const;
-    Result FillFunctionTable(HelperInterface& table) const;
-    Result FillFunctionTable(LowLatencyInterface& table) const;
-    Result FillFunctionTable(MeshShaderInterface& table) const;
-    Result FillFunctionTable(RayTracingInterface& table) const;
-    Result FillFunctionTable(StreamerInterface& table) const;
-    Result FillFunctionTable(SwapChainInterface& table) const;
-    Result FillFunctionTable(ResourceAllocatorInterface& table) const;
-    Result FillFunctionTable(WrapperVKInterface& table) const;
+    void Destruct() override;
+    Result FillFunctionTable(CoreInterface& table) const override;
+    Result FillFunctionTable(HelperInterface& table) const override;
+    Result FillFunctionTable(LowLatencyInterface& table) const override;
+    Result FillFunctionTable(MeshShaderInterface& table) const override;
+    Result FillFunctionTable(RayTracingInterface& table) const override;
+    Result FillFunctionTable(StreamerInterface& table) const override;
+    Result FillFunctionTable(SwapChainInterface& table) const override;
+    Result FillFunctionTable(ResourceAllocatorInterface& table) const override;
+    Result FillFunctionTable(WrapperVKInterface& table) const override;
 
     //================================================================================================================
     // NRI

--- a/Source/Validation/DeviceVal.h
+++ b/Source/Validation/DeviceVal.h
@@ -72,29 +72,29 @@ struct DeviceVal final : public DeviceBase {
         return m_Lock;
     }
 
-    const DeviceDesc& GetDesc() const {
-        return ((DeviceBase&)m_Device).GetDesc();
-    }
-
     bool Create();
     void RegisterMemoryType(MemoryType memoryType, MemoryLocation memoryLocation);
 
     //================================================================================================================
     // DeviceBase
     //================================================================================================================
+    
+    const DeviceDesc& GetDesc() const override{
+        return ((DeviceBase&)m_Device).GetDesc();
+    }
 
-    void Destruct();
-    Result FillFunctionTable(CoreInterface& table) const;
-    Result FillFunctionTable(HelperInterface& table) const;
-    Result FillFunctionTable(LowLatencyInterface& table) const;
-    Result FillFunctionTable(MeshShaderInterface& table) const;
-    Result FillFunctionTable(ResourceAllocatorInterface& table) const;
-    Result FillFunctionTable(RayTracingInterface& table) const;
-    Result FillFunctionTable(StreamerInterface& table) const;
-    Result FillFunctionTable(SwapChainInterface& table) const;
-    Result FillFunctionTable(WrapperD3D11Interface& table) const;
-    Result FillFunctionTable(WrapperD3D12Interface& table) const;
-    Result FillFunctionTable(WrapperVKInterface& table) const;
+    void Destruct() override;
+    Result FillFunctionTable(CoreInterface& table) const override;
+    Result FillFunctionTable(HelperInterface& table) const override;
+    Result FillFunctionTable(LowLatencyInterface& table) const override;
+    Result FillFunctionTable(MeshShaderInterface& table) const override;
+    Result FillFunctionTable(ResourceAllocatorInterface& table) const override;
+    Result FillFunctionTable(RayTracingInterface& table) const override;
+    Result FillFunctionTable(StreamerInterface& table) const override;
+    Result FillFunctionTable(SwapChainInterface& table) const override;
+    Result FillFunctionTable(WrapperD3D11Interface& table) const override;
+    Result FillFunctionTable(WrapperD3D12Interface& table) const override;
+    Result FillFunctionTable(WrapperVKInterface& table) const override;
 
     //================================================================================================================
     // NRI


### PR DESCRIPTION
I get a warning in xcode for these methods. might be a good idea to mark these as overriden, should help catch problems if DeviceBase is ever changed in a way where these are not considered overridden. 

Its a nitpick change but this should be easy to verify for correctness. 